### PR TITLE
feat: shared crypto pool, configurable timeouts, session hardening

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -39,7 +39,7 @@ from typing import AsyncGenerator, Callable, List, Optional, Type, Union
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
 from pyrogram.crypto import aes
-from pyrogram.crypto.executor import create_crypto_executor
+from pyrogram.crypto.executor import get_crypto_executor
 from pyrogram.errors import (
     AuthBytesInvalid,
     BadRequest,
@@ -277,7 +277,18 @@ class Client(Methods):
     CHATLIST_INVITE_RE = re.compile(r"^(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/(?:addlist/|\+))([\w-]+)$")
     SAVED_GIFT_RE = re.compile(r"^(-\d+)_(\d+)$")
     CHANNEL_MESSAGE_LINK_RE = re.compile(r"^(?:https?://)?(?:www\.)?(?:t(?:elegram)?\.(?:org|me|dog)/(?:c/)?)([\w]+)(?:.+)?$")
-    WORKERS = min(32, (os.cpu_count() or 0) + 4)  # os.cpu_count() can be None
+    def _default_workers() -> int:
+        override = os.environ.get("WZGRAM_WORKERS")
+
+        if override:
+            try:
+                return max(1, int(override))
+            except ValueError:
+                pass
+
+        return min(32, (os.cpu_count() or 0) + 4)
+
+    WORKERS = _default_workers()
     WORKDIR = PARENT_DIR
 
     # Interval of seconds in which the updates watchdog will kick in
@@ -386,7 +397,7 @@ class Client(Methods):
         self.auto_no_updates = auto_no_updates
 
         self.executor = ThreadPoolExecutor(max(1, self.workers // 4), thread_name_prefix="Handler")
-        self.crypto_executor = create_crypto_executor()
+        self.crypto_executor = get_crypto_executor()
 
         self.storage: Storage
 
@@ -1623,6 +1634,7 @@ class Client(Methods):
             is_media=is_media,
             server_address=server_address,
             port=port,
+            crypto_executor=self.crypto_executor,
         )
 
         if not temporary:
@@ -1663,6 +1675,7 @@ class Client(Methods):
         )
         session = Session(
             self, dc_id, auth_key, await self.storage.test_mode(), is_media=True,
+            crypto_executor=self.crypto_executor,
         )
         await session.start()
         if dc_id != await self.storage.dc_id():

--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -21,7 +21,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Type
 
-from pyrogram.crypto.executor import create_crypto_executor
+from pyrogram.crypto.executor import get_crypto_executor
 from .transport import TCP, TCPAbridged
 from ..session.internals import DataCenter, get_dc_address
 
@@ -51,11 +51,9 @@ class Connection:
         self.media = media
         self.protocol_factory = protocol_factory
         if crypto_executor is None:
-            self.crypto_executor = create_crypto_executor()
-            self._owned_executor = True
+            self.crypto_executor = get_crypto_executor()
         else:
             self.crypto_executor = crypto_executor
-            self._owned_executor = False
 
         if server_address and port:
             self.address = (server_address, port)
@@ -96,8 +94,6 @@ class Connection:
     async def close(self):
         if self.protocol is None:
             return
-        if self._owned_executor:
-            self.crypto_executor.shutdown(wait=False)
         async with self.protocol.lock:
             await self.protocol.close()
         log.info("Disconnected")

--- a/pyrogram/connection/transport/tcp/tcp.py
+++ b/pyrogram/connection/transport/tcp/tcp.py
@@ -26,13 +26,14 @@ from typing import Optional
 
 import socks
 
-from pyrogram.crypto.executor import create_crypto_executor
+from pyrogram.crypto.executor import get_crypto_executor
 
 log = logging.getLogger(__name__)
 
 
 class TCP:
-    TIMEOUT = 10
+    TIMEOUT = int(os.environ.get("WZGRAM_TCP_TIMEOUT", 10))
+    CONNECT_TIMEOUT = int(os.environ.get("WZGRAM_TCP_CONNECT_TIMEOUT", 600))
 
     def __init__(self, ipv6: bool, proxy: dict, crypto_executor: Optional[ThreadPoolExecutor] = None, loop: Optional[asyncio.AbstractEventLoop] = None):
         self.socket = None
@@ -51,7 +52,7 @@ class TCP:
 
         self.proxy = proxy
 
-        self.crypto_executor = crypto_executor or create_crypto_executor()
+        self.crypto_executor = crypto_executor or get_crypto_executor()
 
         if proxy:
             hostname = proxy.get("hostname")
@@ -75,7 +76,7 @@ class TCP:
                 password=proxy.get("password", None)
             )
 
-            self.socket.settimeout(TCP.TIMEOUT)
+            self.socket.settimeout(TCP.CONNECT_TIMEOUT)
 
             log.info("Using proxy %s", hostname)
         else:
@@ -91,13 +92,13 @@ class TCP:
             try:
                 await asyncio.wait_for(
                     self.loop.run_in_executor(None, self.socket.connect, address),
-                    TCP.TIMEOUT
+                    TCP.CONNECT_TIMEOUT
                 )
             except asyncio.TimeoutError:
                 raise TimeoutError("Proxy connection timed out")
         else:
             try:
-                await asyncio.wait_for(self.loop.sock_connect(self.socket, address), TCP.TIMEOUT)
+                await asyncio.wait_for(self.loop.sock_connect(self.socket, address), TCP.CONNECT_TIMEOUT)
             except asyncio.TimeoutError:
                 raise TimeoutError("Connection timed out")
 

--- a/pyrogram/crypto/executor.py
+++ b/pyrogram/crypto/executor.py
@@ -2,6 +2,41 @@ import os
 from concurrent.futures.thread import ThreadPoolExecutor
 
 
+def _default_crypto_workers() -> int:
+    override = os.environ.get("WZGRAM_CRYPTO_WORKERS")
+
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+
+    # warpcrypto releases the GIL for MTProto framing, so a small pool gives
+    # real parallel crypto for the media sessions used in parallel transfers
+    # (DOWNLOAD_POOL_SIZE / POOL_SIZE are 4-20). Capping avoids spawning
+    # cpu_count threads on big boxes — each thread costs a stack plus allocator
+    # arenas that a 256 MB host can't afford.
+    return min(4, max(1, os.cpu_count() or 1))
+
+
+_crypto_pool = None
+
+
+def get_crypto_executor() -> ThreadPoolExecutor:
+    global _crypto_pool
+    if _crypto_pool is None:
+        _crypto_pool = ThreadPoolExecutor(
+            max_workers=_default_crypto_workers(),
+            thread_name_prefix="Crypto"
+        )
+    return _crypto_pool
+
+
+def set_crypto_executor(executor: ThreadPoolExecutor):
+    global _crypto_pool
+    _crypto_pool = executor
+
+
 def create_crypto_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(
         max_workers=1,

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -307,7 +307,7 @@ class SaveFile:
                 for _ in workers:
                     await queue.put(None)
 
-                await asyncio.gather(*workers)
+                await asyncio.gather(*workers, return_exceptions=True)
 
                 if isinstance(path, (str, PurePath)):
                     fp.close()

--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -32,6 +32,7 @@ import warpcrypto
 import pyrogram
 from pyrogram import raw
 from pyrogram.connection import Connection
+from pyrogram.crypto.executor import get_crypto_executor
 from pyrogram.errors import (
     RPCError, InternalServerError, AuthKeyDuplicated, FloodWait, FloodPremiumWait, ServiceUnavailable,
     BadMsgNotification, SecurityCheckMismatch
@@ -85,13 +86,9 @@ class Session:
         self.server_address = server_address
         self.port = port
         if crypto_executor is None:
-            self.crypto_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="Crypto"
-            )
-            self._owned_executor = True
+            self.crypto_executor = get_crypto_executor()
         else:
             self.crypto_executor = crypto_executor
-            self._owned_executor = False
 
         self.connection = None
 
@@ -135,7 +132,9 @@ class Session:
 
     async def start(self):
         self._stopping = False
+        attempt = 0
         while True:
+            attempt += 1
             self.connection = Connection(
                 self.dc_id,
                 self.test_mode,
@@ -183,10 +182,17 @@ class Session:
                 raise e
             except (OSError, RPCError):
                 await self.stop()
-                if self._owned_executor:
-                    self.crypto_executor = ThreadPoolExecutor(
-                        max_workers=1, thread_name_prefix="Crypto"
-                    )
+
+                # Exponential backoff (capped) so a flaky network doesn't make
+                # the session spin in a tight connect/retry loop. Reconnects are
+                # especially expensive on low-memory hosts, so slow the loop
+                # down instead of thrashing.
+                backoff = min(2 ** (attempt - 1), 30)
+                log.debug(
+                    "Session start attempt %d failed, retrying in %ss",
+                    attempt, backoff
+                )
+                await asyncio.sleep(backoff)
             except (Exception, asyncio.CancelledError) as e:
                 await self.stop()
                 raise e
@@ -229,8 +235,10 @@ class Session:
         if self.connection:
             await self.connection.close()
 
-        if self._owned_executor:
-            self.crypto_executor.shutdown(wait=False)
+        # Wake every in-flight request so it re-checks state (and retries via
+        # invoke) instead of hanging until its own timeout.
+        for result in self.results.values():
+            result.event.set()
 
         if not self.is_media and callable(self.client.disconnect_handler):
             try:
@@ -248,11 +256,6 @@ class Session:
             self._restart_done.clear()
             try:
                 await self.stop()
-                if self._owned_executor:
-                    self.crypto_executor.shutdown(wait=False)
-                    self.crypto_executor = ThreadPoolExecutor(
-                        max_workers=1, thread_name_prefix="Crypto"
-                    )
                 if self.client.storage.conn is None:
                     await self.client.storage.open()
                 await self.start()
@@ -260,14 +263,20 @@ class Session:
                 self._restart_done.set()
 
     async def handle_packet(self, packet):
-        msg_id, seq_no, length, body_bytes, total_len = await self.loop.run_in_executor(
-            self.connection.protocol.crypto_executor,
-            warpcrypto.unpack_message,
-            packet,
-            self.session_id,
-            self.auth_key,
-            self.auth_key_id
-        )
+        try:
+            msg_id, seq_no, length, body_bytes, total_len = await self.loop.run_in_executor(
+                self.connection.protocol.crypto_executor,
+                warpcrypto.unpack_message,
+                packet,
+                self.session_id,
+                self.auth_key,
+                self.auth_key_id
+            )
+        except Exception as e:
+            # A corrupt/undecryptable frame (or a protocol torn down by a
+            # concurrent restart) must not kill the background task.
+            log.warning("Failed to decrypt packet: %s %s", type(e).__name__, e)
+            return
 
         # https://core.telegram.org/mtproto/security_guidelines#checking-message-length
         padding_len = total_len - 16 - length
@@ -376,7 +385,7 @@ class Session:
                         ping_id=0, disconnect_delay=self.WAIT_TIMEOUT + 10
                     ), False
                 )
-            except (OSError, RPCError):
+            except (OSError, TimeoutError, RPCError):
                 pass
 
         log.info("PingTask stopped")
@@ -439,6 +448,9 @@ class Session:
 
     async def send(self, data: TLObject, wait_response: bool = True, timeout: float = WAIT_TIMEOUT,
                    retry: int = 0):
+        if self.connection is None or self.connection.protocol is None:
+            raise OSError("Connection is not established")
+
         message = self.msg_factory(data)
         msg_id = message.msg_id
 
@@ -475,8 +487,10 @@ class Session:
                 await asyncio.wait_for(self.results[msg_id].event.wait(), timeout)
             except asyncio.TimeoutError:
                 pass
-
-            result = self.results.pop(msg_id).value
+            finally:
+                # Always release the pending request so a cancelled caller
+                # doesn't leak an entry into self.results.
+                result = self.results.pop(msg_id).value
 
             if result is None:
                 raise TimeoutError("Request timed out")


### PR DESCRIPTION
- Share a single capped crypto executor (WZGRAM_CRYPTO_WORKERS) across all sessions instead of spawning a thread pool per session/connection, cutting peak RAM on hosts with large media pools.
- Make TCP timeouts configurable (WZGRAM_TCP_TIMEOUT, WZGRAM_TCP_CONNECT_TIMEOUT) and use a 600s connect timeout so slow networks/proxies don't fail connects.
- Guard send() against a torn-down protocol, guard packet decryption against corrupt frames, and wake in-flight requests on stop() so a restart never leaves callers hanging.
- Add capped exponential backoff to session start so a flaky network retries slowly instead of spinning.
- Reuse the media session pool for the first download chunk and keep upload worker cleanup from propagating exceptions (return_exceptions=True).
- Allow overriding worker count via WZGRAM_WORKERS.