### PR TITLE
feat: a discussion thread streams in order, and remembers where it left off

### DIFF
--- a/pyrogram/methods/messages/get_discussion_replies.py
+++ b/pyrogram/methods/messages/get_discussion_replies.py
@@ -16,10 +16,48 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncGenerator
+from datetime import datetime
+from typing import AsyncGenerator, Optional, Union
 
 import pyrogram
-from pyrogram import types, raw
+from pyrogram import raw, types, utils
+
+
+async def get_chunk(
+    *,
+    client: "pyrogram.Client",
+    chat_id: Union[int, str],
+    message_id: int,
+    limit: int = 0,
+    offset: int = 0,
+    from_message_id: int = 0,
+    from_date: datetime = utils.zero_datetime(),
+    min_id: int = 0,
+    max_id: int = 0,
+    reverse: bool = False,
+):
+    from_message_id = from_message_id or (1 if reverse else 0)
+
+    messages = await client.invoke(
+        raw.functions.messages.GetReplies(
+            peer=await client.resolve_peer(chat_id),
+            msg_id=message_id,
+            offset_id=from_message_id,
+            offset_date=utils.datetime_to_timestamp(from_date),
+            add_offset=offset * (-1 if reverse else 1) - (limit if reverse else 0),
+            limit=limit,
+            max_id=max_id,
+            min_id=min_id,
+            hash=0,
+        ),
+        sleep_threshold=60,
+    )
+
+    messages = await utils.parse_messages(client, messages, replies=0)
+    if reverse:
+        messages.reverse()
+
+    return messages
 
 
 class GetDiscussionReplies:
@@ -28,6 +66,12 @@ class GetDiscussionReplies:
         chat_id: Union[int, str],
         message_id: int,
         limit: int = 0,
+        offset: int = 0,
+        offset_id: int = 0,
+        offset_date: datetime = utils.zero_datetime(),
+        min_id: int = 0,
+        max_id: int = 0,
+        reverse: bool = False,
     ) -> Optional[AsyncGenerator["types.Message", None]]:
         """Get the message replies of a discussion thread.
 
@@ -44,6 +88,25 @@ class GetDiscussionReplies:
                 Limits the number of messages to be retrieved.
                 By default, no limit is applied and all messages are returned.
 
+            offset (``int``, *optional*):
+                Sequential number of the first message to be returned.
+                Negative values are also accepted and become useful in case you set offset_id or offset_date.
+
+            offset_id (``int``, *optional*):
+                Identifier of the first message to be returned.
+
+            offset_date (:py:obj:`~datetime.datetime`, *optional*):
+                Pass a date as offset to retrieve only older messages starting from that date.
+
+            min_id (``int``, *optional*):
+                If a positive value was provided, the method will return only messages with IDs more than min_id.
+
+            max_id (``int``, *optional*):
+                If a positive value was provided, the method will return only messages with IDs less than max_id.
+
+            reverse (``bool``, *optional*):
+                Pass True to retrieve the messages from oldest to newest.
+
         Yields:
             :obj:`~pyrogram.types.Message` objects.
 
@@ -51,7 +114,7 @@ class GetDiscussionReplies:
             .. code-block:: python
 
                 async for message in app.get_discussion_replies(chat_id, message_id):
-                    print(message)
+                    print(message.text)
         """
 
         current = 0
@@ -59,29 +122,28 @@ class GetDiscussionReplies:
         limit = min(100, total)
 
         while True:
-            r = await self.invoke(
-                raw.functions.messages.GetReplies(
-                    peer=await self.resolve_peer(chat_id),
-                    msg_id=message_id,
-                    offset_id=0,
-                    offset_date=0,
-                    add_offset=current,
-                    limit=limit,
-                    max_id=0,
-                    min_id=0,
-                    hash=0
-                )
+            messages = await get_chunk(
+                client=self,
+                chat_id=chat_id,
+                message_id=message_id,
+                limit=limit,
+                offset=offset,
+                from_message_id=offset_id,
+                from_date=offset_date,
+                min_id=min_id,
+                max_id=max_id,
+                reverse=reverse,
             )
-
-            users = {u.id: u for u in r.users}
-            chats = {c.id: c for c in r.chats}
-            messages = r.messages
 
             if not messages:
                 return
 
+            offset_id = messages[-1].id
+            if reverse:
+                offset_id += 1
+
             for message in messages:
-                yield await types.Message._parse(self, message, users, chats, replies=0)
+                yield message
 
                 current += 1
 


### PR DESCRIPTION
messages.GetReplies carries offset_id, offset_date, add_offset, min_id and
max_id, but the method passed literal zeros and incremented add_offset alone.
That locked iteration into reverse chronological order, and made resuming from
a checkpoint impossible without reading the whole thread first.

Passing offset_id, offset_date, min_id and max_id through settles the forward
pagination and checkpoint cases. Setting reverse=True applies the negative limit
offset that asks the server for the next batch ahead rather than behind,
stepping offset_id by one on each chunk the way
get_direct_messages_chat_topic_history does.

Fixes rjriajul/wzgram#10