### PR TITLE
fix: parse inline location properly and correct effect_id default

### DIFF
--- a/pyrogram/types/inline_mode/chosen_inline_result.py
+++ b/pyrogram/types/inline_mode/chosen_inline_result.py
@@ -81,10 +81,6 @@ class ChosenInlineResult(Object, Update):
             result_id=str(chosen_inline_result.id),
             from_user=types.User._parse(client, users[chosen_inline_result.user_id]),
             query=chosen_inline_result.query,
-            location=types.Location(
-                longitude=chosen_inline_result.geo.long,
-                latitude=chosen_inline_result.geo.lat,
-                client=client
-            ) if chosen_inline_result.geo else None,
+            location=types.Location._parse(chosen_inline_result.geo) if chosen_inline_result.geo else None,
             inline_message_id=inline_message_id
         )

--- a/pyrogram/types/inline_mode/inline_query.py
+++ b/pyrogram/types/inline_mode/inline_query.py
@@ -98,11 +98,7 @@ class InlineQuery(Object, Update):
             query=inline_query.query,
             offset=inline_query.offset,
             chat_type=chat_type,
-            location=types.Location(
-                longitude=inline_query.geo.long,
-                latitude=inline_query.geo.lat,
-                client=client
-            ) if inline_query.geo else None,
+            location=types.Location._parse(inline_query.geo) if inline_query.geo else None,
             client=client
         )
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3590,7 +3590,7 @@ class Message(Object, Update):
         game_short_name: str,
         disable_notification: Optional[bool] = None,
         message_thread_id: Optional[int] = None,
-        effect_id: int = Optional[None],
+        effect_id: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[
@@ -3685,7 +3685,7 @@ class Message(Object, Update):
         game_short_name: str,
         disable_notification: Optional[bool] = None,
         message_thread_id: Optional[int] = None,
-        effect_id: int = Optional[None],
+        effect_id: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[


### PR DESCRIPTION
When an inline query with geo-location coordinates is received or
selected, InlineQuery._parse and ChosenInlineResult._parse previously
attempted to directly instantiate types.Location with client=client.
Because Location.__init__ does not accept a client parameter, this
resulted in a runtime TypeError crashing bot inline handlers.

Both parsers now delegate parsing of geo attributes to the static
factory method types.Location._parse(...), which matches standard
parsing behavior throughout the library and cleanly parses
raw.types.GeoPoint instances or returns None for missing coordinates.

In addition, reply_game and answer_game in message.py incorrectly
defined effect_id: int = Optional[None]. At runtime Optional[None]
evaluates to <class 'NoneType'>, causing MTProto serialization failures
when invocations omitted effect_id. The default has been corrected to
effect_id: Optional[int] = None to match the rest of message.py.